### PR TITLE
v0.6.11 - createDeleteMutation - dont use fragment, just primary keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tesseractcollective/react-native-graphql",
+  "name": "@tesseractcollective/react-graphql",
   "version": "0.6.10",
   "private": false,
   "main": "./dist/src/index.js",

--- a/src/hooks/useMutate.utils.tsx
+++ b/src/hooks/useMutate.utils.tsx
@@ -93,14 +93,11 @@ export function createDeleteMutation(
 
   const variablesStr = variableDefinitionsString ? `(${variableDefinitionsString})` : '';
 
-  let frag = buildFragment(fragment, operationName, variablesForDeleting);
-
   const mutationStr = `mutation ${name}DeleteMutation${variablesStr} {
       ${operationName}(${pkArgs}) {
-        ...${fragmentName}
+        ${config.primaryKey.join('\r\n')}
       }
-    }
-    ${frag}`;
+    }`;
 
   let document = buildDocument(mutationStr, operationName, variablesForDeleting, 'createDeleteMutation', 'mutation');
 


### PR DESCRIPTION
When deleting an item, if the fragment contains relationships we get a DB error thrown `Cannot determine type of parameter $1`.

By ignoring the fragment for a delete and only using PK this is safer and will require fewer configs/fragments to be made.