### PR TITLE
Use mutate jsonb

### DIFF
--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -316,8 +316,12 @@ export interface SelectViaRelationshipProps extends UseInfiniteQueryManyProps {
   relationshipColumnNameForLabel: String;
   relationshipColumnNameForValue: String;
   autoSave?: boolean;
-  menuStyle?: ViewProps | Readonly<ViewProps>;
-  containerStyle?: ViewProps | Readonly<ViewProps>;
+  styles?: {
+    containerStyle?: ViewProps | Readonly<ViewProps>;
+    menuStyle?: ViewProps | Readonly<ViewProps>;
+    itemStyle?: ViewProps | Readonly<ViewProps>;
+    itemActiveStyle?: ViewProps | Readonly<ViewProps>;
+  };
   where?: any;
 }
 
@@ -329,6 +333,7 @@ export interface SelectViaRelationshipProps extends UseInfiniteQueryManyProps {
     relationshipColumnNameForLabel,
     relationshipColumnNameForValue,
     autoSave,
+    styles,
     ...rest
   } = props;
 
@@ -366,7 +371,7 @@ export interface SelectViaRelationshipProps extends UseInfiniteQueryManyProps {
 
   const onChange = (e: any) => {
     const selectedLabel = e.value || e;
-    const selectedValue = optionsValueToLabelMap[selectedLabel];
+    const selectedValue = optionsLabelToValueMap[selectedLabel];
     if (selectedValue && autoSave) {
       state.executeMutation({ [name]: selectedValue });
     } else {
@@ -391,9 +396,10 @@ export interface SelectViaRelationshipProps extends UseInfiniteQueryManyProps {
   }
 
   //TODO: P3: BONUS: Try to get the popup to show the list of items without having to type first
+  
 
   return (
-    <View style={props.containerStyle}>
+    <View style={props.styles?.containerStyle}>
       <Autocomplete
         items={options}
         onChangeText={(e: any) => {
@@ -404,6 +410,9 @@ export interface SelectViaRelationshipProps extends UseInfiniteQueryManyProps {
         onSelect={onChange}
         getItemValue={(itm: any) => itm.value}
         getItemLabel={(itm: any) => itm.label}
+        itemStyle={props.styles?.itemStyle}
+        menuStyle={props.styles?.menuStyle}
+        itemActiveStyle={props.styles?.itemActiveStyle}
       />
     </View>
   );
@@ -478,7 +487,7 @@ export interface IInputCheckboxManyProps extends IInputProps {
   };
 
   const renderCheckboxMany = () =>
-    items.map((item:any) => {
+    items.map((item: any) => {
       return (
         <RNWUICheckbox
           checked={values.includes(item)}

--- a/src/hooks/useMutate.tsx
+++ b/src/hooks/useMutate.tsx
@@ -19,7 +19,7 @@ import { JsonObject } from "type-fest";
 import { IUseOperationStateHelperOptions, useOperationStateHelper } from "./useOperationStateHelper";
 
 
-interface IUseMutateProps {
+export interface IUseMutateProps {
   sharedConfig: HasuraDataConfig;
   middleware: QueryMiddleware[];
   initialItem?: JsonObject;

--- a/src/hooks/useMutateJsonb.tsx
+++ b/src/hooks/useMutateJsonb.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState, useCallback } from 'react';
+import { HasuraDataConfig } from '../types/hasuraConfig';
+import { QueryMiddleware, QueryPostMiddlewareState } from '../types/hookMiddleware';
+import { OperationContext, useMutation, UseMutationState } from 'urql';
+import { stateFromQueryMiddleware } from '../support/middlewareHelpers';
+import { useMonitorResult } from './support/monitorResult';
+import { mutationEventAtom } from './support/mutationEventAtom';
+import { useAtom } from 'jotai';
+import { keyExtractor } from '../support/HasuraConfigUtils';
+import { print } from 'graphql';
+import { JsonObject } from 'type-fest';
+import { IUseOperationStateHelperOptions, useOperationStateHelper } from './useOperationStateHelper';
+import { IUseMutateProps, MutateState } from './useMutate';
+
+interface IUseMutateJsonbProps extends IUseMutateProps {
+  columnName?: string;
+}
+
+export function useMutateJsonb<T extends JsonObject>(props: IUseMutateJsonbProps): MutateState {
+  const { sharedConfig, middleware, initialVariables, initialItem, listKey, operationEventType, columnName } = props;
+  //MutationConfig is what we internally refer to the middlewareState as
+
+  const [variables, setVariables] = useState<JsonObject>(initialVariables || {});
+  const [item, setItem] = useState<JsonObject | undefined>(initialItem);
+  const [needsExecuteMutation, setNeedsExecuteMutation] = useState<boolean>();
+  const [executeContext, setExecuteContext] = useState<Partial<OperationContext> | null>();
+  const [_, setMutationEvent] = useAtom(mutationEventAtom);
+
+  const _columnName = columnName || sharedConfig.jsonb?.columnName;
+
+  //Guards
+  if (!sharedConfig) {
+    throw new Error('config if required, recieved: ' + sharedConfig);
+  }
+  if (!middleware?.length) {
+    throw new Error('At least one middleware required');
+  }
+  if (!_columnName) {
+    throw new Error('Column name required as paramter, or on config.jsonb.columnName for useMutateJsonb');
+  }
+  const computeConfig = (variables: JsonObject, item?: JsonObject) => {
+    const variablesWithItem = {
+      ...variables,
+      item,
+    };
+
+    return stateFromQueryMiddleware({ variables: variablesWithItem }, middleware, sharedConfig);
+  };
+
+  const [mutationCfg, setMutationCfg] = useState(computeConfig(variables, item));
+  useEffect(() => {
+    const newState = computeConfig(variables, item);
+    setMutationCfg(newState);
+  }, [variables, item]);
+
+  //The mutation
+  const [mutationResult, executeMutation] = useMutation(mutationCfg.document);
+  const resultItem = mutationResult.data?.[mutationCfg.operationName];
+
+  useEffect(() => {
+    (async () => {
+      if (needsExecuteMutation && !executeContext) {
+        setNeedsExecuteMutation(false);
+
+        console.log('💪 executingMutation');
+        console.log(print(mutationCfg.document));
+        console.log(JSON.stringify({ variables: mutationCfg.variables }));
+
+        //_append, _prepend, set -> These all expect an object with the shape of: { columnName: CHANGES }
+        //for _append and _prepend this should be an object that is added to the existing array
+        //for _set: this will replace the entire jsonb
+        //_delete_elem -> This expects a number to know which index number to delete at
+        const vars =
+          operationEventType === 'delete'
+            ? {
+                item: {
+                  [_columnName]: mutationCfg.variables.index,
+                },
+              }
+            : {
+                item: {
+                  [_columnName]: mutationCfg.variables,
+                },
+              };
+
+        const resp = await executeMutation(vars);
+        const successItem = resp?.data?.[mutationCfg.operationName];
+
+        if (successItem) {
+          const key = keyExtractor(sharedConfig, successItem);
+          console.log('setMutationEvent');
+
+          setMutationEvent(() => ({
+            listKey: listKey ?? sharedConfig.typename,
+            type: props.operationEventType,
+            key: key,
+            payload: {
+              ...successItem,
+            },
+          }));
+        }
+      }
+    })();
+  }, [needsExecuteMutation, executeContext, executeMutation, mutationCfg]);
+
+  useMonitorResult('mutation', mutationResult, mutationCfg);
+
+  //Handling variables
+  const setVariable = useCallback((name: string, value: any) => {
+    setVariables((original) => ({
+      ...original,
+      [name]: value,
+    }));
+  }, []);
+
+  const setItemValue = useCallback((key: string, value: any) => {
+    if (operationEventType === 'delete') {
+      if (key !== 'index') {
+        console.error('When deleting jsonb the only item key you can set is "index".  You tried to set: ' + key);
+        return;
+      }
+      if (typeof value !== 'number') {
+        console.error('When deleting jsonb you can only set an item value = to a number. You gave RG: ' + value);
+        return;
+      }
+    }
+    setItem((original) => ({
+      ...original,
+      [key]: value,
+    }));
+  }, []);
+
+  const wrappedExecuteMutation = (
+    _itemValues?: JsonObject,
+    _variables?: JsonObject,
+    context?: Partial<OperationContext>,
+  ) => {
+    if (_variables || _itemValues) {
+      const newVariables = {
+        ...variables,
+        ..._variables,
+      };
+      const newItem = {
+        ...item,
+        ..._itemValues,
+      };
+
+      // you need to do both because setVariables triggers the
+      // useEffect to compute the new config on the next render
+      // cycle
+      setMutationCfg(computeConfig(newVariables, newItem));
+      setVariables(newVariables);
+      setItem(newItem);
+    }
+    if (context) {
+      setExecuteContext(context);
+    } else {
+      setNeedsExecuteMutation(true);
+    }
+  };
+
+  useOperationStateHelper(mutationResult, props.resultHelperOptions || {});
+
+  //Return values
+  return {
+    resultItem,
+    mutating: mutationResult.fetching,
+    error: mutationResult.error,
+    mutationState: mutationResult,
+    mutationConfig: mutationCfg,
+    executeMutation: wrappedExecuteMutation,
+    item,
+    setItemValue,
+    variables,
+    setVariable,
+  };
+}

--- a/src/hooks/useReactGraphql.tsx
+++ b/src/hooks/useReactGraphql.tsx
@@ -5,7 +5,13 @@ import { QueryMiddleware } from '../types/hookMiddleware';
 import { useInfiniteQueryMany } from './useInfiniteQueryMany';
 import { createInfiniteQueryMany } from './useInfiniteQueryMany.utils';
 import { useMutate } from './useMutate';
-import { createDeleteMutation, createInsertMutation, createUpdateMutation } from './useMutate.utils';
+import { useMutateJsonb } from './useMutateJsonb';
+import {
+  createDeleteMutation,
+  createInsertMutation,
+  createUpdateJsonbMutation,
+  createUpdateMutation,
+} from './useMutate.utils';
 import { useMutateExisting } from './useMutateExisting';
 import { IUseOperationStateHelperOptions } from './useOperationStateHelper';
 import { useQueryOne } from './useQueryOne';
@@ -85,6 +91,60 @@ export function useReactGraphql(config: HasuraDataConfig) {
         queryMiddleware: props?.queryMiddleware || [createQueryOne],
         queryVariables: props?.initialVariables || {},
         mutationResultHelperOptions: props?.mutationResultHelperOptions,
+      }),
+
+    useInsertJsonb: (props?: {
+      initialVariables?: JsonObject;
+      initialItem?: JsonObject;
+      middleware?: QueryMiddleware[];
+      listKey?: string;
+      firstOrLast?: 'insert-first' | 'insert-last';
+      resultHelperOptions?: IUseOperationStateHelperOptions;
+      columnName?: string;
+    }) =>
+      useMutateJsonb({
+        sharedConfig: config,
+        middleware: props?.middleware || [createUpdateJsonbMutation],
+        initialItem: props?.initialItem,
+        initialVariables: props?.initialVariables,
+        operationEventType: props?.firstOrLast ?? 'insert-first',
+        listKey: props?.listKey,
+        resultHelperOptions: props?.resultHelperOptions,
+        columnName: props?.columnName,
+      }),
+
+    useDeleteJsonb: (props: {
+      variables: JsonObject;
+      middleware?: QueryMiddleware[];
+      listKey?: string;
+      resultHelperOptions?: IUseOperationStateHelperOptions;
+      columnName?: string;
+    }) =>
+      useMutateJsonb({
+        sharedConfig: config,
+        middleware: props.middleware || [createUpdateJsonbMutation],
+        initialVariables: props.variables,
+        operationEventType: 'delete',
+        listKey: props.listKey,
+        resultHelperOptions: props?.resultHelperOptions,
+        columnName: props?.columnName,
+      }),
+
+    useUpdateJsonb: (props?: {
+      initialItem?: JsonObject;
+      initialVariables?: JsonObject;
+      middleware?: QueryMiddleware[];
+      resultHelperOptions?: IUseOperationStateHelperOptions;
+      columnName?: string;
+    }) =>
+      useMutateJsonb({
+        sharedConfig: config,
+        middleware: props?.middleware || [createUpdateJsonbMutation],
+        initialItem: props?.initialItem,
+        initialVariables: props?.initialVariables,
+        operationEventType: 'update',
+        resultHelperOptions: props?.resultHelperOptions,
+        columnName: props?.columnName,
       }),
 
     useInfiniteQueryMany: function <TData>(props?: UseInfiniteQueryManyProps) {

--- a/src/types/hasuraConfig/index.ts
+++ b/src/types/hasuraConfig/index.ts
@@ -16,6 +16,9 @@ export interface HasuraDataConfig {
     fieldSimpleMap: { [key: string]: IFieldOutputType } 
     fieldTypeMap: { [key: string]: GraphQLOutputType}
   };
+  jsonb?: {
+    columnName: string;
+  };
   overrides?: {
     operationNames?: {
       query_many?: string;


### PR DESCRIPTION
This is all we should need for jsonb support.

It builds on existing patterns and only requires specifying an additional column name in the config or when creating the hook.

Getting jsonb can be done via useQueryOne.
PaginatedTable already accepts a "dataOverride" object it can use to render data.