### PR TITLE
Fix/ useInfiniteQueryMany calls useEffect for clear items many times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseractcollective/react-graphql",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "This library provides hooks and components to easily interact with opinionated graphql APIs. It includes patterns do create paginated lists, admin interface data grids, and edit views.",
   "keywords": [
     "hasura",

--- a/src/hooks/useInfiniteQueryMany.tsx
+++ b/src/hooks/useInfiniteQueryMany.tsx
@@ -201,8 +201,11 @@ export function useInfiniteQueryMany<TData extends any>(
         });
       }
     }
-    setQueryStateStored(queryState);
-  }, [queryState]);
+  }, [queryState.data]);
+
+  useEffect(() => {
+    setQueryStateStored(queryState)
+  },[queryState])
 
   //Effect/react on mutation events
   const [mutationEvent] = useAtom<IMutationEvent>(mutationEventAtom);


### PR DESCRIPTION
- the main problem was that the where parameters were not reflected when the `isInfinite` argument was true.
- there was a bug that caused the saved items not to be updated correctly, the modified useEffect in line 133 was called many times because its trigger was `queryState` and this stored multiple variables (loading, error, data, etc) of which it was only necessary to perform the effect when data changed.
- an improvement in the items loading times was noticed.

previous behavior
![gif-before](https://user-images.githubusercontent.com/31198370/151061269-e2d0b609-330d-465d-9b61-51709d09c467.gif)

behavior after changes
![gif-after](https://user-images.githubusercontent.com/31198370/151061275-36f347c1-190a-4085-9274-e2d5889c79b6.gif)
